### PR TITLE
Bumped version number to v1.1.0 in the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ create a bash script within the root of your project like this one:
 doctoolchain.sh
 ```bash
 #!/usr/bin/env bash
-docker run --rm -it --entrypoint /bin/bash -v ${PWD}:/project rdmueller/doctoolchain:rc-1.0.0 \
+docker run --rm -it --entrypoint /bin/bash -v ${PWD}:/project rdmueller/doctoolchain:v1.1.0 \
 -c "doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 -PmainConfigFile=config/docToolchain.groovy && exit"
 ```
 
@@ -26,5 +26,5 @@ With this script, you use docToolchain on your project like this:
 on windows, the following batch script does the same:
 
 ```
-docker run --rm --entrypoint /bin/bash -it -v %cd%:/project rdmueller/doctoolchain:rc-1.0.0 -c "doctoolchain . %1 %2 %3 %4 %5 %6 %7 %8 %9 -PmainConfigFile=config/docToolchain.groovy && exit"
+docker run --rm --entrypoint /bin/bash -it -v %cd%:/project rdmueller/doctoolchain:v1.1.0 -c "doctoolchain . %1 %2 %3 %4 %5 %6 %7 %8 %9 -PmainConfigFile=config/docToolchain.groovy && exit"
 ```


### PR DESCRIPTION
Just a simple fix of the version number in the README,