### PR TITLE
Update Dockerfile syntax error

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -35,7 +35,7 @@ RUN	echo "Install java, groovy" && \
 
 RUN     git clone https://github.com/docToolchain/docToolchain.git && \
         cd docToolchain && \
-        git checkout v1.1.0
+        git checkout v1.1.0 && \
         git submodule update -i && \
         ./gradlew tasks && \
         ./gradlew && \


### PR DESCRIPTION
The last commit added an incomplete `git checkout` line which causes a syntax error when building the Docker image.