### PR TITLE
Add libc6-compat to build PDFs containing graphviz

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,6 +12,7 @@ RUN	echo "add needed tools" && \
     python \
     ruby \
     py-pygments \
+    libc6-compat \
     ttf-dejavu && \
     gem install rdoc --no-document && \
     gem install pygments.rb


### PR DESCRIPTION
Including the `libc6-compat` package allows me to build PDFs with graphviz diagrams included. I have an example skeleton repository here: https://github.com/ko/doctoolchain-docker-image-graphviz-test that can be used to reproduce this with the `v1.1.0` image. 

NOTE: This fix may be considered heavy-handed. I imagine there may be a more precise fix.

From using that repository, above, the build output for the `v1.1.0` image is: 



```
$ make clean
rm -rf build
$ make test_pre
image_name=rdmueller/doctoolchain \
						 image_version=v1.1.0 \
						 ./doctoolchain.sh generatePDF
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
:generatePDF
Converting /project/src/docs/index.adoc
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/open3.rb:206: warning: executable? does not in this environment and will return a dummy value
Error: dot: can't open {:in=>#<IO:fd 250>, :out=>#<IO:fd 253>, :err=>#<IO:fd 255>}
(NotImplementedError) waitpid unsupported or native support failed to load; see http://wiki.jruby.org/Native-Libraries
:generatePDF FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':generatePDF'.
> Error running Asciidoctor

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 45s
1 actionable task: 1 executed
make: *** [test_pre] Error 1
```

while the locally built image (with `libc6-compat`) has the build output:

```
$ make clean
rm -rf build
$ make test_fix
image_name=local.test \
						 image_version=latest \
						 ./doctoolchain.sh generatePDF
Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
:generatePDF
Converting /project/src/docs/index.adoc

BUILD SUCCESSFUL in 1m 5s
1 actionable task: 1 executed
```