### PR TITLE
Reduce size of docker image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,6 +38,8 @@ RUN     git clone https://github.com/docToolchain/docToolchain.git && \
         cd docToolchain && \
         git checkout v1.2.0 && \
         git submodule update -i && \
+        # remove .git folders
+        rm -rf `find -type d -name .git` && \
         ./gradlew tasks && \
         ./gradlew && \
         PATH="/docToolchain/bin:${PATH}"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -34,7 +34,7 @@ RUN	echo "Install java, groovy" && \
     source $HOME/.sdkman/bin/sdkman-init.sh
 #    sdk install groovy 2.5.5
 
-RUN     git clone https://github.com/docToolchain/docToolchain.git && \
+RUN     git clone --depth 1 https://github.com/docToolchain/docToolchain.git && \
         cd docToolchain && \
         git checkout v1.2.0 && \
         git submodule update -i && \


### PR DESCRIPTION
As proposed in https://github.com/docToolchain/docker-image/issues/7 added line will remove ".git" folders to reduce size of the result docToolchain image