### PR TITLE
Install mmdc, to allow the rendering of mermaid diagrams

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -25,6 +25,18 @@ RUN gem install pygments.rb
 #RUN apk add --no-cache cmark --repository http://nl.alpinelinux.org/alpine/edge/testing && \
 #    apk add --no-cache --allow-untrusted pandoc --repository https://conoria.gitlab.io/alpine-pandoc/
 
+# Add mermaid
+ENV CHROME_BIN="/usr/bin/chromium-browser" \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
+RUN apk add --no-cache npm && \
+    # Dependencies for running puppeteer
+    apk add --no-cache chromium  terminus-font ttf-dejavu ttf-freefont ttf-inconsolata ttf-linux-libertine && \
+    fc-cache -f && \
+    npm install @mermaid-js/mermaid-cli
+ADD puppeteer-config.json /puppeteer-config.json
+ADD mmdc /usr/local/bin/mmdc
+RUN chmod +x /usr/local/bin/mmdc
+
 SHELL ["/bin/bash", "-c"]
 
 USER dtcuser

--- a/alpine/mmdc
+++ b/alpine/mmdc
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/node_modules/.bin/mmdc -p /puppeteer-config.json "$@"

--- a/alpine/puppeteer-config.json
+++ b/alpine/puppeteer-config.json
@@ -1,0 +1,6 @@
+{
+    "executablePath": "/usr/bin/chromium-browser",
+    "args": [
+        "--no-sandbox"
+    ]
+}


### PR DESCRIPTION
In the current version the rendering of Mermaid diagrams is not working

> Failed to generate image: Could not find the 'mmdc' executable in PATH; add it to the PATH or specify its location using the 'mmdc' document attribute

In this Pull request the mmdc is installed in the docker image. 