### PR TITLE
download releases to install docToolchain into container

### DIFF
--- a/alpine-latest/Dockerfile
+++ b/alpine-latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 
 # see https://github.com/docker-library/openjdk/issues/73
 ENV LC_CTYPE en_US.UTF-8
@@ -34,24 +34,20 @@ ENV HOME=/home/dtcuser
 ENV GRADLE_USER_HOME=/home/dtcuser/.gradle
 
 ARG DTC_VERSION
-RUN     git clone --branch ng https://github.com/docToolchain/docToolchain.git  && \
-        cd docToolchain && \
-        git fetch --tags && \
-        git checkout ${DTC_VERSION} && \
-        git submodule update -i && \
-        # remove .git folders
-        rm -rf `find -type d -name .git` && \
-        umask g+w && \
-        ./gradlew downloadDependencies && \
-        chmod -R o=u $GRADLE_USER_HOME && \
-        chmod -R g=u $GRADLE_USER_HOME && \
-        rm -r $GRADLE_USER_HOME/daemon && \
-        chmod -R o=u $HOME
-
-# add reveal.js
-RUN     cd /home/dtcuser/docToolchain/resources/. && \
-        ./clone.sh && \
-        cd -
+RUN curl -LO https://github.com/docToolchain/docToolchain/releases/download/${DTC_VERSION}/docToolchain-${DTC_VERSION#?}.zip \
+    && unzip docToolchain-${DTC_VERSION#?}.zip \
+    && mv docToolchain-${DTC_VERSION#?} docToolchain \
+    && rm docToolchain-${DTC_VERSION#?}.zip \
+    && cd docToolchain \
+    # This is a workaround to suppress the initialization phase of docToolchain.  \
+    # We should consider a '--no-init' option in the future.
+    && cp template_config/Config.groovy . \
+    && umask g+w  \
+    && ./gradlew downloadDependencies  \
+    && chmod -R o=u $GRADLE_USER_HOME  \
+    && chmod -R g=u $GRADLE_USER_HOME  \
+    && rm -r $GRADLE_USER_HOME/daemon  \
+    && chmod -R o=u $HOME
 
 ENV PATH="/home/dtcuser/docToolchain/bin:${PATH}"
 

--- a/alpine-with-pandoc/Dockerfile
+++ b/alpine-with-pandoc/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 
 # see https://github.com/docker-library/openjdk/issues/73
 ENV LC_CTYPE en_US.UTF-8
@@ -33,21 +33,20 @@ ENV HOME=/home/dtcuser
 ENV GRADLE_USER_HOME=/home/dtcuser/.gradle
 
 ARG DTC_VERSION
-RUN     git clone --branch ng https://github.com/docToolchain/docToolchain.git  && \
-        cd docToolchain && \
-        git fetch --tags && \
-        git checkout ${DTC_VERSION} && \
-        git submodule update -i && \
-        # remove .git folders
-        rm -rf `find -type d -name .git` && \
-        umask g+w && \
-        ./gradlew downloadDependencies && \
-        chmod -R o=u $GRADLE_USER_HOME && \
-        chmod -R g=u $GRADLE_USER_HOME && \
-        rm -r $GRADLE_USER_HOME/daemon && \
-        chmod -R o=u $HOME
-
-
+RUN curl -LO https://github.com/docToolchain/docToolchain/releases/download/${DTC_VERSION}/docToolchain-${DTC_VERSION#?}.zip \
+    && unzip docToolchain-${DTC_VERSION#?}.zip \
+    && mv docToolchain-${DTC_VERSION#?} docToolchain \
+    && rm docToolchain-${DTC_VERSION#?}.zip \
+    && cd docToolchain \
+    # This is a workaround to suppress the initialization phase of docToolchain.  \
+    # We should consider a '--no-init' option in the future.
+    && cp template_config/Config.groovy . \
+    && umask g+w  \
+    && ./gradlew downloadDependencies  \
+    && chmod -R o=u $GRADLE_USER_HOME  \
+    && chmod -R g=u $GRADLE_USER_HOME  \
+    && rm -r $GRADLE_USER_HOME/daemon  \
+    && chmod -R o=u $HOME
 ENV PATH="/home/dtcuser/docToolchain/bin:${PATH}"
 
 USER dtcuser

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk-alpine
+FROM eclipse-temurin:17-jdk-alpine
 
 # see https://github.com/docker-library/openjdk/issues/73
 ENV LC_CTYPE en_US.UTF-8
@@ -34,20 +34,20 @@ ENV HOME=/home/dtcuser
 ENV GRADLE_USER_HOME=/home/dtcuser/.gradle
 
 ARG DTC_VERSION
-RUN     git clone --branch ng https://github.com/docToolchain/docToolchain.git  && \
-        cd docToolchain && \
-        git fetch --tags && \
-        git checkout ${DTC_VERSION} && \
-        git submodule update -i && \
-        # remove .git folders
-        rm -rf `find -type d -name .git` && \
-        umask g+w && \
-        ./gradlew downloadDependencies && \
-        chmod -R o=u $GRADLE_USER_HOME && \
-        chmod -R g=u $GRADLE_USER_HOME && \
-        rm -r $GRADLE_USER_HOME/daemon && \
-        chmod -R o=u $HOME
-
+RUN curl -LO https://github.com/docToolchain/docToolchain/releases/download/${DTC_VERSION}/docToolchain-${DTC_VERSION#?}.zip \
+    && unzip docToolchain-${DTC_VERSION#?}.zip \
+    && mv docToolchain-${DTC_VERSION#?} docToolchain \
+    && rm docToolchain-${DTC_VERSION#?}.zip \
+    && cd docToolchain \
+    # This is a workaround to suppress the initialization phase of docToolchain.  \
+    # We should consider a '--no-init' option in the future.
+    && cp template_config/Config.groovy . \
+    && umask g+w  \
+    && ./gradlew downloadDependencies  \
+    && chmod -R o=u $GRADLE_USER_HOME  \
+    && chmod -R g=u $GRADLE_USER_HOME  \
+    && rm -r $GRADLE_USER_HOME/daemon  \
+    && chmod -R o=u $HOME
 
 ENV PATH="/home/dtcuser/docToolchain/bin:${PATH}"
 

--- a/jenkins-ssh-agent/Dockerfile
+++ b/jenkins-ssh-agent/Dockerfile
@@ -32,20 +32,22 @@ ENV HOME=/home/jenkins
 ENV GRADLE_USER_HOME=/home/jenkins/.gradle
 
 ARG DTC_VERSION
-RUN     cd ${HOME} && \
-        git clone --branch ng https://github.com/docToolchain/docToolchain.git && \
-        cd docToolchain && \
-        git fetch --tags && \
-        git checkout ${DTC_VERSION} && \
-        git submodule update -i && \
-        # remove .git folders
-        rm -rf `find -type d -name .git` && \
-        umask g+w && \
-        ./gradlew tasks && \
-        ./gradlew dependencies && \
-        ./gradlew generatePDF && \
-        rm -r $GRADLE_USER_HOME/daemon && \
-        chmod -R a+w ${GRADLE_USER_HOME}
+RUN mkdir docToolchain \
+    && curl -LO https://github.com/docToolchain/docToolchain/releases/download/${DTC_VERSION}/docToolchain-${DTC_VERSION#?}.zip \
+    && unzip docToolchain-${DTC_VERSION#?}.zip -d docToolchain \
+    && rm docToolchain-${DTC_VERSION#?}.zip \
+    && cd docToolchain \
+    # This is a workaround to suppress the initialization phase of docToolchain.  \
+    # We should consider a '--no-init' option in the future.
+    && cp template_config/Config.groovy . \
+    && umask g+w  \
+    && ./gradlew tasks  \
+    && ./gradlew dependencies \
+    && ./gradlew generatePDF \
+    && chmod -R o=u $GRADLE_USER_HOME  \
+    && chmod -R g=u $GRADLE_USER_HOME  \
+    && rm -r $GRADLE_USER_HOME/daemon  \
+    && chmod -R o=u $HOME
 
 # This is for interactive usage
 ENV PATH="/home/jenkins/docToolchain/bin:${PATH}"


### PR DESCRIPTION
we should consider to use the release as source to have the same behaviour as if you would install via dtcw locally