### PR TITLE
feat: add repository_dispatch for automated releases

### DIFF
--- a/.github/workflows/azure-build.yml
+++ b/.github/workflows/azure-build.yml
@@ -1,6 +1,8 @@
 name: Build and push 'azure image' to Docker
 
 on:
+  repository_dispatch:
+    types: [azure-build]
   push:
     branches:
       - 'master'
@@ -11,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DTC_VERSION: v3.4.2
+  DTC_VERSION: ${{ github.event.client_payload.version || 'v3.4.2' }}
 
 jobs:
   docker:

--- a/.github/workflows/jenkins-ssh-agent-build.yml
+++ b/.github/workflows/jenkins-ssh-agent-build.yml
@@ -1,6 +1,8 @@
 name: Build and push Docker image for 'jenkins-ssh-agent'
 
 on:
+  repository_dispatch:
+    types: [jenkins-ssh-agent-build]
   push:
     branches:
       - 'master'
@@ -11,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DTC_VERSION: v3.4.2
+  DTC_VERSION: ${{ github.event.client_payload.version || 'v3.4.2' }}
 
 jobs:
   docker:

--- a/.github/workflows/standard-build.yml
+++ b/.github/workflows/standard-build.yml
@@ -1,6 +1,8 @@
 name: Build and push 'standard image' to Docker
 
 on:
+  repository_dispatch:
+    types: [standard-build]
   push:
     branches:
       - 'master'
@@ -11,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DTC_VERSION: v3.4.2
+  DTC_VERSION: ${{ github.event.client_payload.version || 'v3.4.2' }}
 
 jobs:
   docker:

--- a/.github/workflows/standard-with-pandoc-build.yml
+++ b/.github/workflows/standard-with-pandoc-build.yml
@@ -1,6 +1,8 @@
 name: Build and push 'standard pandoc image' to Docker
 
 on:
+  repository_dispatch:
+    types: [standard-with-pandoc-build]
   push:
     branches:
       - 'master'
@@ -11,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DTC_VERSION: v3.4.2
+  DTC_VERSION: ${{ github.event.client_payload.version || 'v3.4.2' }}
 
 jobs:
   docker:


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` trigger to all 4 Docker build workflows
- Make `DTC_VERSION` dynamic: accepts version from dispatch payload, falls back to hardcoded default
- Backward compatible: push and manual triggers continue to work unchanged

## Changed Workflows
- `standard-build.yml` → event type: `standard-build`
- `standard-with-pandoc-build.yml` → event type: `standard-with-pandoc-build`
- `azure-build.yml` → event type: `azure-build`
- `jenkins-ssh-agent-build.yml` → event type: `jenkins-ssh-agent-build`

## Context
This enables the upcoming automated release workflow in the main docToolchain repo to trigger Docker image builds with a specific version via `repository_dispatch`.

## Test plan
- [ ] Verify existing push-triggered builds still work (fallback to `v3.4.2`)
- [ ] Test `repository_dispatch` with payload `{"version": "v4.0.0-rc1"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)